### PR TITLE
Add vmware.ssh_info_public = true

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       v.enable_vmrun_ip_lookup = false
       v.linked_clone = true
       v.vmx["vhv.enable"] = "TRUE"
+      v.ssh_info_public = true
     end
   end
 


### PR DESCRIPTION
During tests with VMware Workstation 14.1.0 https://github.com/hashicorp/vagrant/issues/9348 it may help to use the IP address of the VM with the WinRM port instead of relying on the NAT port forwarding to localhost.

The port forwarding still happens, but Vagrant uses the IP address:

```
$ dm start 2016
~/code/windows-docker-machine ~/code/windows-docker-machine
Bringing machine '2016' up with 'vmware_fusion' provider...
==> 2016: Verifying vmnet devices are healthy...
==> 2016: Preparing network adapters...
==> 2016: Fixed port collision for 3389 => 3389. Now on port 2200.
==> 2016: Fixed port collision for 5985 => 55985. Now on port 2201.
==> 2016: Fixed port collision for 5986 => 55986. Now on port 2202.
==> 2016: Fixed port collision for 22 => 2222. Now on port 2203.
==> 2016: Starting the VMware VM...
==> 2016: Waiting for the VM to receive an address...
==> 2016: Forwarding ports...
    2016: -- 3389 => 2200
    2016: -- 5985 => 2201
    2016: -- 5986 => 2202
    2016: -- 22 => 2203
==> 2016: Waiting for machine to boot. This may take a few minutes...
    2016: WinRM address: 192.168.65.130:5985
    2016: WinRM username: vagrant
    2016: WinRM execution_time_limit: PT2H
    2016: WinRM transport: negotiate
==> 2016: Machine booted and ready!
```

  