### PR TITLE
Increase memory for lcow box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "lcow", autostart: false do |cfg|
     cfg.vm.box     = "windows_server_1709_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName lcow -enableLCOW"
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.memory = 4096
+      end
+    end
   end
   
   ["vmware_fusion", "vmware_workstation"].each do |provider|


### PR DESCRIPTION
A small fix for #22. Increase the memory of the VM to run Hyper-V containers. 2 GB for the host is not enough to run Linux containers as Hyper-V containers.
