### PR TITLE
add 1803 lcow config and allow experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ decide which Vagrant VM should be started.
 * `1803` - Windows Server, version 1803 (10.0.17134) Semi annual channel
 * `insider` - Windows Server Insider builds
 * `lcow` - Windows Server, version 1709 with LCOW enabled
+* `lcow-1803` - Windows Server, version 1803 with LCOW enabled
 
 So with a `vagrant up 2016` you spin up the LTS version, with `vagrant up 1709`
 the 1709 version and with `vagrant up insider` the Insider build.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
   end
+  
+  config.vm.define "lcow-1803", autostart: false do |cfg|
+    cfg.vm.box     = "windows_server_1803_docker"
+    cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName lcow-1803 -enableLCOW"
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.memory = 5120
+      end
+    end
+  end
 
   ["vmware_fusion", "vmware_workstation"].each do |provider|
     config.vm.provider provider do |v, override|

--- a/scripts/create-machine.ps1
+++ b/scripts/create-machine.ps1
@@ -1,4 +1,4 @@
-param ([String] $machineHome, [String] $machineName, [String] $machineIp, [Switch] $enableLCOW)
+param ([String] $machineHome, [String] $machineName, [String] $machineIp, [Switch] $enableLCOW, [Switch] $experimental)
 
 if (!(Test-Path $env:USERPROFILE\.docker)) {
   mkdir $env:USERPROFILE\.docker
@@ -143,13 +143,12 @@ function createCerts($rootCert, $serverCertsPath, $serverName, $ipAddresses, $cl
   copy $serverCertsPath\ca.pem $clientCertsPath\ca.pem
 }
 
-function updateConfig($daemonJson, $serverCertsPath, $enableLCOW) {
+function updateConfig($daemonJson, $serverCertsPath, $enableLCOW, $experimental) {
   $config = @{}
   if (Test-Path $daemonJson) {
     $config = (Get-Content $daemonJson) -join "`n" | ConvertFrom-Json
   }
 
-  $experimental = $false
   if ($enableLCOW) {
     $experimental = $true
   }
@@ -282,7 +281,7 @@ $clientCertsPath = "$userPath"
 $rootCert = createCA "$dockerData\certs.d"
 
 createCerts $rootCert $serverCertsPath $serverName $ipAddresses $clientCertsPath
-updateConfig "$dockerData\config\daemon.json" $serverCertsPath $enableLCOW
+updateConfig "$dockerData\config\daemon.json" $serverCertsPath $enableLCOW $experimental
 
 if ($machineName) {
   $machinePath = "$env:USERPROFILE\.docker\machine\machines\$machineName"


### PR DESCRIPTION
this adds a config for lcow on a 1803 box and it allows enabling experimental directly if you want to use it without lcow