### PR TITLE
Set experimental to false

### DIFF
--- a/scripts/create-machine.ps1
+++ b/scripts/create-machine.ps1
@@ -151,6 +151,9 @@ function updateConfig($daemonJson, $serverCertsPath, $enableLCOW, $experimental)
     $config = (Get-Content $daemonJson) -join "`n" | ConvertFrom-Json
   }
 
+  if (!$experimental) {
+    $experimental = $false
+  }
   if ($enableLCOW) {
     $experimental = $true
   }


### PR DESCRIPTION
Explicit set $experimental to $false if it isn't defined as a script parameter.
Otherwise the created daemon.json was invalid:

![Error in daemon.json, creates a section Experimental with key IsPresent equals to false](https://user-images.githubusercontent.com/207759/41181228-53e38572-6b71-11e8-8f42-1ea16a226ecb.png)

