### PR TITLE
Add 1809 machine, update lcow to 1809

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@ containers and the Windows containers.
 There are several versions of Windows Server. This is where you
 decide which Vagrant VM should be started.
 
-* `2019` - Windows Server 2019 (10.0.17763) LTS channel
-* `1803` - Windows Server, version 1803 (10.0.17134) Semi annual channel
-* `1709` - Windows Server, version 1709 (10.0.16299) Semi annual channel
+* `2019` - Windows Server 2019 (10.0.17763) LTS Channel
+* `1809` - Windows Server, version 1809 (10.0.17763) Semi-Annual Channel
+* `1803` - Windows Server, version 1803 (10.0.17134) Semi-Annual Channel
+* `1709` - Windows Server, version 1709 (10.0.16299) Semi-Annual Channel
 * `2016` - Windows Server 2016 (10.0.14393) LTS channel
 * `insider` - Windows Server Insider builds
 * `lcow` - Windows Server, version 1709 with LCOW enabled
 * `lcow-1803` - Windows Server, version 1803 with LCOW enabled
 
-So with a `vagrant up 2019` you spin up the LTS version, with `vagrant up 1803`
-the 1803 semi-annual version and with `vagrant up insider` the Insider build.
+So with a `vagrant up 2019` you spin up the LTS version, with `vagrant up 1809`
+the 1809 semi-annual version and with `vagrant up insider` the Insider build.
 
 If you don't want to run the **packer** step, you can run `vagrant up 2019-box`
 and get your box downloaded directly from [Vagrant Cloud](https://app.vagrantup.com/StefanScherer/boxes/windows_2019_docker).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,11 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 1803"
   end
 
+  config.vm.define "1809", autostart: false do |cfg|
+    cfg.vm.box     = "windows_server_1809_docker"
+    cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 1809"
+  end
+
   config.vm.define "2019", autostart: false do |cfg|
     cfg.vm.box     = "windows_2019_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2019"
@@ -46,18 +51,8 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "lcow", autostart: false do |cfg|
-    cfg.vm.box     = "windows_server_1709_docker"
+    cfg.vm.box     = "windows_server_1809_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName lcow -enableLCOW"
-    ["vmware_fusion", "vmware_workstation"].each do |provider|
-      config.vm.provider provider do |v, override|
-        v.memory = 5120
-      end
-    end
-  end
-  
-  config.vm.define "lcow-1803", autostart: false do |cfg|
-    cfg.vm.box     = "windows_server_1803_docker"
-    cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName lcow-1803 -enableLCOW"
     ["vmware_fusion", "vmware_workstation"].each do |provider|
       config.vm.provider provider do |v, override|
         v.memory = 5120

--- a/scripts/create-machine.ps1
+++ b/scripts/create-machine.ps1
@@ -40,17 +40,17 @@ function installLCOW() {
   Write-Host "    Downloading LCOW LinuxKit ..."
   $ProgressPreference = 'SilentlyContinue'
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  Invoke-WebRequest -OutFile "$env:TEMP\linuxkit-lcow.zip" "https://github.com/linuxkit/lcow/releases/download/4.14.29-0aea33bc/release.zip"
+  Invoke-WebRequest -OutFile "$env:TEMP\linuxkit-lcow.zip" "https://github.com/linuxkit/lcow/releases/download/v4.14.35-v0.3.9/release.zip"
   Expand-Archive -Path "$env:TEMP\linuxkit-lcow.zip" -DestinationPath "$env:ProgramFiles\Linux Containers" -Force
-  if (Test-Path "$env:ProgramFiles\Linux Containers\bootx64.efi") {
-    Move-Item "$env:ProgramFiles\Linux Containers\bootx64.efi" "$env:ProgramFiles\Linux Containers\kernel" -Force
-  }
+  # if (Test-Path "$env:ProgramFiles\Linux Containers\bootx64.efi") {
+  #   Move-Item "$env:ProgramFiles\Linux Containers\bootx64.efi" "$env:ProgramFiles\Linux Containers\kernel" -Force
+  # }
   Remove-Item "$env:TEMP\linuxkit-lcow.zip"
 
-  Write-Host "    Downloading docker nightly ..."
-  Invoke-WebRequest -OutFile "$env:TEMP\docker-master.zip" "https://master.dockerproject.com/windows/x86_64/docker.zip"
-  Expand-Archive -Path "$env:TEMP\docker-master.zip" -DestinationPath $env:ProgramFiles -Force
-  Remove-Item "$env:TEMP\docker-master.zip"
+  # Write-Host "    Downloading docker nightly ..."
+  # Invoke-WebRequest -OutFile "$env:TEMP\docker-master.zip" "https://master.dockerproject.com/windows/x86_64/docker.zip"
+  # Expand-Archive -Path "$env:TEMP\docker-master.zip" -DestinationPath $env:ProgramFiles -Force
+  # Remove-Item "$env:TEMP\docker-master.zip"
 }
 
 # https://docs.docker.com/engine/security/https/


### PR DESCRIPTION
- Add `1809` machine with the semi-annual Windows Server, version 1809
- Update `lcow`
  - now running with the Windows Server, version 1809 and Docker 18.09.0
  - update LinuxKit v4.14.35-v0.3.9
