### PR TITLE
Add 2019-box-resized

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ There are several versions of Windows Server. This is where you
 decide which Vagrant VM should be started.
 
 * `2019-box` - Windows Server 2019 (10.0.17763) LTS Channel, ___***prebuilt from Vagrant Cloud***___
+* `2019-box-resized` - The above, with a 80G->150G resized disk.
 * `2019` - Windows Server 2019 (10.0.17763) LTS Channel
 * `1903` - Windows Server, version 1903 (10.0.18362) Semi-Annual Channel
 * `1809` - Windows Server, version 1809 (10.0.17763) Semi-Annual Channel

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,13 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2019-box"
   end
 
+  config.vm.define "2019-box-resized", autostart: false do |cfg|
+    cfg.vm.box     = "StefanScherer/windows_2019_docker"
+    cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2019-box"
+    config.vagrant.plugins = "vagrant-disksize"
+    config.disksize.size = "150GB"
+  end
+
   config.vm.define "insider", autostart: false do |cfg|
     cfg.vm.box     = "windows_server_insider_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName insider"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "2019-box-resized", autostart: false do |cfg|
     cfg.vm.box     = "StefanScherer/windows_2019_docker"
-    cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2019-box"
+    cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2019-box-resized"
     config.vagrant.plugins = "vagrant-disksize"
     config.disksize.size = "150GB"
   end

--- a/scripts/create-machine.ps1
+++ b/scripts/create-machine.ps1
@@ -2,6 +2,12 @@ param ([String] $machineHome, [String] $machineName, [String] $machineIp, [Switc
 
 $ErrorActionPreference = 'Stop';
 
+# Extend volume 1 to the full size of the resized disk
+Set-Content -Value "select volume 1" -Path C:\diskpart.txt
+Add-Content -Value "extend" -Path C:\diskpart.txt
+diskpart /s C:\diskpart.txt
+del C:\diskpart.txt
+
 if (!(Test-Path $env:USERPROFILE\.docker)) {
   mkdir $env:USERPROFILE\.docker
 }


### PR DESCRIPTION
After much irritation banging my head up against how to easily resize the existing box image from the small 80G limit, this uses the vagrant-disksize plugin to resize it to 150G and runs a diskpart to extend volume 1 when the machine is created.
