### PR TITLE
Remove 169.254.246.127

### DIFF
--- a/scripts/create-machine.ps1
+++ b/scripts/create-machine.ps1
@@ -14,6 +14,7 @@ if (!$machineIp) {
       ( ! ($_.InterfaceAlias).StartsWith("vEthernet (") ) `
       -And $_.IPAddress -Ne "127.0.0.1" `
       -And $_.IPAddress -Ne "10.0.2.15" `
+      -And $_.IPAddress -Ne "169.254.246.127" `
     }).IPAddress
 } else {
   $ipAddresses = "$ipAddresses,$machineIp"


### PR DESCRIPTION
Somehow `169.254.246.127` has detected so the `DOCKER ENDPOINT` of `2016-box` become invalid.

```
$ docker context ls
NAME                DESCRIPTION                               DOCKER ENDPOINT                            KUBERNETES ENDPOINT   ORCHESTRATOR
2016-box            2016-box windows-docker-machine           tcp://169.254.246.127 192.168.99.90:2376
2019-box            2019-box windows-docker-machine           tcp://192.168.99.90:2376
default *           Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                                      swarm
```

If I switch to the above `2016-box`, any `docker` command fails and I had to run factory reset.
 
I'm using

```
Client: Docker Engine - Community
 Version:           19.03.5
 API version:       1.40
 Go version:        go1.12.12
 Git commit:        633a0ea
 Built:             Wed Nov 13 07:22:34 2019
 OS/Arch:           darwin/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.5
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.12
  Git commit:       633a0ea
  Built:            Wed Nov 13 07:29:19 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.2.10
  GitCommit:        b34a5c8af56e510852c35414db4c1f4fa6172339
 runc:
  Version:          1.0.0-rc8+dev
  GitCommit:        3e425f80a8c931f88e6d94a8c831b9d5aa481657
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```