### PR TITLE
use the recommended paravirtualization interface for windows hyperv

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,6 +82,10 @@ Vagrant.configure("2") do |config|
     v.memory = 2048
     v.cpus = 2
     v.linked_clone = true
+    # Enable Nested Hardware Virtualisation - requires VirtualBox 6
+    v.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
+    # Use the recommended paravirtualization interface for windows (hyperv) - requires VirtualBox 6
+    v.customize ["modifyvm", :id, "--paravirtprovider", "hyperv"]
     override.vm.network :private_network, ip: "192.168.99.90", gateway: "192.168.99.1"
   end
 


### PR DESCRIPTION
VirtualBox 6 introduced HyperV and nested hardware virtualisation:

<img width="209" alt="vbox" src="https://user-images.githubusercontent.com/4113649/84482164-8931c180-ac97-11ea-8ee7-3d66f9af56f7.png">

This pull request enables those options to improve performance for the virtualbox provider