### PR TITLE
Use different IP addresses for the out-of-the-box "virtualbox" variants

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,9 @@ Vagrant.configure("2") do |config|
   config.vm.define "2016-box", autostart: false do |cfg|
     cfg.vm.box     = "StefanScherer/windows_2016_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2016-box"
+    cfg.vm.provider "virtualbox" do |v, override|
+      override.vm.network :private_network, ip: "192.168.59.50", gateway: "192.168.56.1"
+    end
   end
 
   config.vm.define "1709", autostart: false do |cfg|
@@ -48,6 +51,9 @@ Vagrant.configure("2") do |config|
   config.vm.define "2019-box", autostart: false do |cfg|
     cfg.vm.box     = "StefanScherer/windows_2019_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2019-box"
+    cfg.vm.provider "virtualbox" do |v, override|
+      override.vm.network :private_network, ip: "192.168.59.51", gateway: "192.168.56.1"
+    end
   end
 
   config.vm.define "2022", autostart: false do |cfg|
@@ -58,6 +64,9 @@ Vagrant.configure("2") do |config|
   config.vm.define "2022-box", autostart: false do |cfg|
     cfg.vm.box     = "StefanScherer/windows_2022_docker"
     cfg.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{home} -machineName 2022-box"
+    cfg.vm.provider "virtualbox" do |v, override|
+      override.vm.network :private_network, ip: "192.168.59.52", gateway: "192.168.56.1"
+    end
   end
 
   config.vm.define "insider", autostart: false do |cfg|
@@ -96,7 +105,6 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
     # Use the recommended paravirtualization interface for windows (hyperv) - requires VirtualBox 6
     v.customize ["modifyvm", :id, "--paravirtprovider", "hyperv"]
-    override.vm.network :private_network, ip: "192.168.59.90", gateway: "192.168.56.1"
   end
 
   config.vm.provider "hyperv" do |v|


### PR DESCRIPTION
Dear Stefan,

coming from https://github.com/cicerops/racker/pull/4, we are aiming to run the "out-of-the-box" boxes `2016-box`, `2019-box` and `2022-box` in parallel without getting any conflicts between them.


### Problem
Currently, when first using the `2016-box` and then switching to the `2019-box`, which has been provisioned beforehand already, it croaks because the association with respect to the appropriate Docker context vs. generated TLS certificates goes south.

We have been able to produce different flavors of the same broken situation, here are two examples how this turns out in practice:
```
$ docker --context=2019-box ps
error during connect: Get "https://192.168.59.90:2376/v1.24/containers/json": x509: certificate is valid for 169.254.232.221, 172.30.112.1, 10.0.2.15, 127.0.0.1, not 192.168.59.90

$ docker --context=2019-box ps
error during connect: Get "https://192.168.59.90:2376/v1.24/containers/json": x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "Docker TLS Root")
```

### Workaround
A workaround-like solution is to manually remove the Docker context (`docker context remove 2019-box`) and run the box provisioning again (`vagrant provision 2019-box`). With both invocations, the TLS certificates will get re-generated and the corresponding Docker context will get re-established correctly.


### Solution
The workaround outlined above quickly becomes tedious when aiming to switch back and forth between boxes or even impossible when aiming to run them in parallel.

So, with this patch, each of the "virtualbox"-type VM definitions gets a different IP address which makes the problem go away completely.
```
$ docker context list
NAME                TYPE                DESCRIPTION                               DOCKER ENDPOINT
2016-box            moby                2016-box windows-docker-machine           tcp://192.168.59.50:2376
2019-box            moby                2019-box windows-docker-machine           tcp://192.168.59.51:2376
2022-box            moby                2022-box windows-docker-machine           tcp://192.168.59.52:2376
```

If you think the patch should be adjusted in any way, we are happy to receive any kind of guidance. Specifically, we didn't check how the patch would behave on other Vagrant provider backends than VirtualBox.

With kind regards,
Andreas.
